### PR TITLE
Enable debug mod for all users having PYTHONDEVMODE environment variable

### DIFF
--- a/friendly/debug_helper.py
+++ b/friendly/debug_helper.py
@@ -7,11 +7,14 @@ itself for most users by redirecting them here, and have them
 printed only when debugging mode is activated.
 """
 import sys
+import os
 
 # DEBUG is set to True for me. It can also be set to True from __main__ or when
 # using the debug() command in the console.
 
-DEBUG = r"users\andre\github\friendly" in __file__.lower()
+IS_PYDEV = bool(os.environ.get("PYTHONDEVMODE", False))
+IS_ANDRE = r"users\andre\github\friendly" in __file__.lower()
+DEBUG = IS_PYDEV or IS_ANDRE
 EXIT = False
 
 


### PR DESCRIPTION
The [dev mode](https://docs.python.org/3/library/devmode.html) enable many modules to enter a dev mode, I think this would be a good idea to have this for friendly too.

We may, or may not, reuse the PYTHONDEVMODE variable though, we could use a `FRIENDLY_DEBUG` variable if you don't want friendly to switch to dev mode for too many people.

In Python 3.7+ we could use `sys.flags.dev_mode`, but this attribute does not exist in 3.6 so I stick to the `os.environ`.