### PR TITLE
Make tox pass.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,28 +13,22 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest] # , windows-latest]  # see https://github.com/tox-dev/tox/issues/1570
-        tox:
-          - env: py36
-            python-version: '3.6'
-          - env: py37
-            python-version: '3.7'
-          - env: py38
-            python-version: '3.8'
-          - env: py39
-            python-version: '3.9'
-        include:
-          - tox:
-              env: flake8,black
-              python-version: '3.9'
-            os: ubuntu-latest
-
     name: ${{ matrix.tox.env }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.tox.python-version }}
+          python-version: 3.6
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
       - uses: actions/cache@v2
         with:
           path: |
@@ -47,4 +41,4 @@ jobs:
           python -m pip install --upgrade tox
       - name: run ${{ matrix.tox.env }}
         run: |
-          tox -q -e ${{ matrix.tox.env }} -p all
+          tox -q -p all

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
   build_ubuntu:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest] # , windows-latest]  # see https://github.com/tox-dev/tox/issues/1570
+        os: [ubuntu-latest, macos-latest, windows-latest]
     name: ${{ matrix.tox.env }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     steps:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 black
 pytest
 pytest-cov
+coverage
 flake8
 pre-commit

--- a/tests/unit/test_formatter.py
+++ b/tests/unit/test_formatter.py
@@ -2,11 +2,13 @@
 """
 
 import subprocess
+import sys
+
 
 def run(lang):
     proc = subprocess.run(
         [
-            "venv-friendly3.8/scripts/python",
+            sys.executable,
             "-m",
             "friendly",
             "--formatter",

--- a/tests/unit/test_source_with_args.py
+++ b/tests/unit/test_source_with_args.py
@@ -1,12 +1,14 @@
 """Tests of running a program that uses command line arguments.
 """
 
+import sys
 import subprocess
+
 
 def run(*args):
     proc = subprocess.run(
         [
-            "venv-friendly3.8/scripts/python",
+            sys.executable,
             "-m",
             "friendly",
             "tests/adder.py",

--- a/tox.ini
+++ b/tox.ini
@@ -1,17 +1,43 @@
 [flake8]
 max-line-length = 88
 
+[coverage:run]
+branch = true
+parallel = true
+omit =
+  .tox/*
+  Fake filename
+
+[coverage:report]
+skip_covered = True
+show_missing = True
+exclude_lines =
+    pragma: no cover
+    def __repr__
+    if self\.debug
+    raise AssertionError
+    raise NotImplementedError
+    if __name__ == .__main__.:
+
 [tox]
-envlist = py36, py37, py38, py39, flake8, black
+envlist = py36, py37, py38, py39, flake8, black, coverage
 isolated_build = True
 skip_missing_interpreters = True
 
 [testenv]
 deps = -r requirements-dev.txt
-commands = pytest --cov-report term-missing --cov-fail-under=80 --cov friendly
-
+commands = coverage run -m pytest
 setenv =
-  COVERAGE_FILE=.coverage.{envname}
+  COVERAGE_FILE={toxworkdir}/.coverage.{envname}
+
+[testenv:coverage]
+depends = py36, py37, py38, py39
+parallel_show_output = True
+skip_install = True
+setenv = COVERAGE_FILE={toxworkdir}/.coverage
+commands =
+  coverage combine
+  coverage report --fail-under 80
 
 [testenv:flake8]
 deps = flake8


### PR DESCRIPTION
I combined output of each runs, as for a specific Python version
coverage varies around 75% due to version-specific blocks, combined
it's 80.0%.

I also replaced a hardcoded path.